### PR TITLE
Null session

### DIFF
--- a/lib/accounts_session.rb
+++ b/lib/accounts_session.rb
@@ -12,6 +12,8 @@ require "accounts_session/decoders/jwt_token"
 module AccountsSession
   class Error < StandardError; end
 
+  NULL_SESSION = Session.new
+
   class << self
     def configuration
       @configuration ||= Configuration.new
@@ -30,6 +32,8 @@ module AccountsSession
     end
 
     def from_token(token)
+      return NULL_SESSION if token.nil?
+
       decoded = AccountsSession::Decoders::JwtToken.decode(token)
       flattened = decoded.merge(decoded.fetch("account"))
 

--- a/lib/accounts_session/version.rb
+++ b/lib/accounts_session/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AccountsSession
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/spec/accounts_session_spec.rb
+++ b/spec/accounts_session_spec.rb
@@ -78,6 +78,20 @@ RSpec.describe AccountsSession do
       described_class.from_token(jwt_token)
     end
 
+    context "when token is nil" do
+      let(:jwt_token) { nil }
+
+      it "returns null session" do
+        expect(subject.session_id).to be_nil
+        expect(subject.uuid).to be_nil
+        expect(subject.first_name).to be_nil
+        expect(subject.last_name).to be_nil
+        expect(subject.email).to be_nil
+        expect(subject.avatar_url).to be_nil
+        expect(subject).not_to be_authenticated
+      end
+    end
+
     it "builds session object" do
       expect(subject).to be_a(AccountsSession::Session)
     end


### PR DESCRIPTION
Problem:
- apps using AccountsSession library has to check for token presence before decoding it. We think it should be a responsibility of library.

Solution:
- when token is nil, returns null session object, so the app does not need to check for token presence.