### PR TITLE
Handle false tokens

### DIFF
--- a/lib/accounts_session.rb
+++ b/lib/accounts_session.rb
@@ -32,7 +32,7 @@ module AccountsSession
     end
 
     def from_token(token)
-      return NULL_SESSION if token.nil?
+      return NULL_SESSION unless token
 
       decoded = AccountsSession::Decoders::JwtToken.decode(token)
       flattened = decoded.merge(decoded.fetch("account"))


### PR DESCRIPTION
Somehow we're getting nil token warnings from the JWT gem.

- We're checking for .nil?
- The JWT gem checks for truthiness.
- Passing false will squeak past our check and fail within JWT as a nil token. Passing an empty string results in a different error, which we aren't getting.

This change checks truthiness instead of simply nil.